### PR TITLE
4 gpus per node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # pytorch-nccl-test
+
+## Usage
+
+```shell
+sbatch -A ${your_account}_g batch_nccl.sh
+```
+

--- a/batch_nccl.sh
+++ b/batch_nccl.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-#SBATCH -C gpu -N 2 -t 5
-#SBATCH --ntasks-per-node=8
+#SBATCH -C gpu
+#SBATCH -N 2
+#SBATCH --ntasks-per-node=4
 #SBATCH --gpus-per-task=1
 #SBATCH --gpu-bind=closest
 #SBATCH --exclusive
 #SBATCH -o slurm-nccl-%j.out
+#SBATCH -t 0:02:00
 
-module load pytorch/v1.3.1-gpu
+module load pytorch/2.3.1
 module list
 export NCCL_DEBUG=INFO
 #export NCCL_DEBUG_SUBSYS=ALL

--- a/test_nccl.py
+++ b/test_nccl.py
@@ -18,7 +18,7 @@ def init_workers_nccl_file():
 print('Pytorch version', torch.__version__)
 
 # Configuration
-ranks_per_node = 8
+ranks_per_node = 4
 shape = 2**17
 dtype = torch.float32
 


### PR DESCRIPTION
As far as I can tell, Perlmutter only has 4 gpus per node not 8. 

This PR fixes the number of GPUs and updates the PyTorch module version.

Tested and working 12/4/2024